### PR TITLE
feat(mokuro): W/S shortcuts to scroll analysis panel

### DIFF
--- a/src/components/MokuroReader.tsx
+++ b/src/components/MokuroReader.tsx
@@ -125,6 +125,14 @@ type CacheStorageMode = 'directory' | 'browser'
 
 const DIRECTORY_CACHE_DISPLAY_PATH = `${MOKURO_ANALYSIS_CACHE_DIRNAME}/page-*.json`
 
+// Lift the analysis panel a bit above the focused OCR box's top edge instead
+// of flush-aligning with it, so the panel reads as floating slightly above the
+// sentence it explains.
+const PANEL_TOP_LIFT_PX = 96
+
+// Distance the analysis panel scrolls on each W/S keyboard shortcut.
+const ANALYSIS_PANEL_SCROLL_STEP_PX = 160
+
 const UI_TEXT = {
   zh: {
     title: 'Mokuro Reader',
@@ -504,11 +512,11 @@ export default function MokuroReader() {
       }
 
       const boxRect = target.getBoundingClientRect()
-      // Don't let the panel overlap the OCR list card above it — clamp the top
-      // to the OCR list's bottom edge.
+      // Lift the panel slightly above the focused box, but don't let it overlap
+      // the OCR list card above it — clamp the top to the OCR list's bottom edge.
       const ocrListBottom = ocrListRef.current?.getBoundingClientRect().bottom ?? 8
       const minTop = Math.max(8, ocrListBottom + 8)
-      const top = Math.max(boxRect.top, minTop)
+      const top = Math.max(boxRect.top - PANEL_TOP_LIFT_PX, minTop)
       setPanelTop(top)
       // Cap the panel at the viewport bottom so its contents stay reachable
       // via the panel's own scroll, instead of extending off-screen.
@@ -1024,7 +1032,13 @@ export default function MokuroReader() {
       },
       goToNextPage: () => goToPage(currentPageIndex + 1),
       goToPreviousPage: () => goToPage(currentPageIndex - 1),
-      clearSelection: () => setSelectedBlock(null)
+      clearSelection: () => setSelectedBlock(null),
+      scrollAnalysisUp: () => {
+        analysisScrollRef.current?.scrollBy({ top: -ANALYSIS_PANEL_SCROLL_STEP_PX, behavior: 'smooth' })
+      },
+      scrollAnalysisDown: () => {
+        analysisScrollRef.current?.scrollBy({ top: ANALYSIS_PANEL_SCROLL_STEP_PX, behavior: 'smooth' })
+      }
     },
     state: {
       enabled: Boolean(mokuroFile) && !isBatchAnalyzing,
@@ -1485,7 +1499,8 @@ export default function MokuroReader() {
                     }
                   : undefined
               }
-              className="rounded-2xl border border-white/10 bg-white/5 p-4"
+              className="rounded-2xl border border-white/10 bg-white/5 p-4 data-[fixed=true]:!mt-0"
+              data-fixed={panelAnchor && panelTop !== null ? 'true' : undefined}
             >
               <MokuroAnalysisPanel
                 analysisResult={activeAnalysis}

--- a/src/components/useMokuroKeyboardNav.ts
+++ b/src/components/useMokuroKeyboardNav.ts
@@ -14,6 +14,8 @@ export interface MokuroKeyboardNavHandlers {
   goToNextPage: () => void
   goToPreviousPage: () => void
   clearSelection: () => void
+  scrollAnalysisUp: () => void
+  scrollAnalysisDown: () => void
 }
 
 export interface UseMokuroKeyboardNavArgs {
@@ -84,6 +86,12 @@ export const useMokuroKeyboardNav = ({ handlers, state }: UseMokuroKeyboardNavAr
           if (current.blockIndices.length > 0) {
             h.selectBlock(current.blockIndices[current.blockIndices.length - 1])
           }
+          break
+        case 'scroll-analysis-up':
+          h.scrollAnalysisUp()
+          break
+        case 'scroll-analysis-down':
+          h.scrollAnalysisDown()
           break
       }
     }

--- a/src/lib/mokuro-keyboard-nav.test.ts
+++ b/src/lib/mokuro-keyboard-nav.test.ts
@@ -93,7 +93,14 @@ describe('resolveAction', () => {
     expect(resolveAction('End', state())).toBe('end')
   })
 
-  it('disables block navigation and Enter while analyzing, but keeps paging and clear/home/end', () => {
+  it('maps left-hand w/s to scroll the analysis panel', () => {
+    expect(resolveAction('w', state())).toBe('scroll-analysis-up')
+    expect(resolveAction('W', state())).toBe('scroll-analysis-up')
+    expect(resolveAction('s', state())).toBe('scroll-analysis-down')
+    expect(resolveAction('S', state())).toBe('scroll-analysis-down')
+  })
+
+  it('disables block navigation and Enter while analyzing, but keeps paging, clear/home/end, and panel scrolling', () => {
     const analyzing = state({ isAnalyzing: true })
     expect(resolveAction('ArrowUp', analyzing)).toBeNull()
     expect(resolveAction('ArrowDown', analyzing)).toBeNull()
@@ -103,6 +110,8 @@ describe('resolveAction', () => {
     expect(resolveAction('Escape', analyzing)).toBe('clear')
     expect(resolveAction('Home', analyzing)).toBe('home')
     expect(resolveAction('End', analyzing)).toBe('end')
+    expect(resolveAction('w', analyzing)).toBe('scroll-analysis-up')
+    expect(resolveAction('s', analyzing)).toBe('scroll-analysis-down')
   })
 
   it('returns null for unknown keys', () => {

--- a/src/lib/mokuro-keyboard-nav.ts
+++ b/src/lib/mokuro-keyboard-nav.ts
@@ -7,6 +7,8 @@ export type KeyboardNavAction =
   | 'clear'
   | 'home'
   | 'end'
+  | 'scroll-analysis-up'
+  | 'scroll-analysis-down'
 
 export interface KeyTargetContext {
   tagName: string | null
@@ -63,6 +65,12 @@ export const resolveAction = (
   if (key === 'Escape') return 'clear'
   if (key === 'Home') return 'home'
   if (key === 'End') return 'end'
+
+  // Scroll the analysis panel with left-hand keys; available even while a
+  // single block is analyzing so the reader can review its content.
+  const lowerKey = key.toLowerCase()
+  if (lowerKey === 'w') return 'scroll-analysis-up'
+  if (lowerKey === 's') return 'scroll-analysis-down'
 
   if (state.isAnalyzing) return null
 


### PR DESCRIPTION
## Summary

Add left-hand `W`/`S` keyboard shortcuts to scroll the Mokuro analysis panel, and lift the panel slightly above the focused OCR box.

## Changes

- **Keyboard nav** (`src/lib/mokuro-keyboard-nav.ts`, `useMokuroKeyboardNav.ts`): map `w`/`s` to `scroll-analysis-up` / `scroll-analysis-down`. Available even while a single block is analyzing, so the reader can review panel content mid-analysis.
- **MokuroReader** (`src/components/MokuroReader.tsx`):
  - Add `PANEL_TOP_LIFT_PX` so the panel floats slightly above the focused box's top edge instead of flush-aligning (still clamped below the OCR list card).
  - Add `ANALYSIS_PANEL_SCROLL_STEP_PX` for the W/S scroll step.
  - Add `data-fixed` styling hook so the anchored panel keeps a tight top margin.
- **Tests** (`src/lib/mokuro-keyboard-nav.test.ts`): cover `w`/`s` mapping incl. while analyzing.

## Verification

- `npm test` → 109 passed
- `npm run lint` → 0 errors (only pre-existing `<img>` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)