### PR TITLE
fix(jlpt): tolerate CRLF in checksummed dataset files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# JLPT dataset files are checksummed against their LF representation (the
+# generator writes LF and stores the LF hash in the manifest). Force LF in the
+# working tree so core.autocrlf on Windows can't serve CRLF and break checksum
+# verification. See src/lib/jlpt-dictionary.ts and src/lib/jlpt-grammar-dictionary.ts.
+public/data/** eol=lf

--- a/src/lib/jlpt-dictionary.test.ts
+++ b/src/lib/jlpt-dictionary.test.ts
@@ -54,6 +54,21 @@ describe('loadJLPTDictionary', () => {
     await expect(loadJLPTDictionary(fetchMock)).resolves.toMatchObject({ status: 'error' })
   })
 
+  it('verifies the checksum even when the served data has CRLF line endings', async () => {
+    // The generator writes LF and stores the LF hash in the manifest. A Windows
+    // checkout with core.autocrlf serves CRLF; the loader must normalize before
+    // digesting or every Windows dev/CI sees "JLPT data checksum mismatch".
+    const fixtures = await responseSet()
+    const crlfDataText = fixtures.dataText.replace(/\n/g, '\r\n')
+    const fetchMock = async (input: RequestInfo | URL) => new Response(
+      String(input).includes('manifest') ? fixtures.manifestText : crlfDataText
+    )
+    const result = await loadJLPTDictionary(fetchMock)
+    expect(result.status).toBe('ready')
+    if (result.status !== 'ready') throw result.error
+    expect(result.dictionary.classify('猫', 'ねこ').match).toBe('exact')
+  })
+
   it('fails closed on dataset version mismatch', async () => {
     const fixtures = await responseSet({ datasetVersion: 'wrong-version' })
     const fetchMock = async (input: RequestInfo | URL) => new Response(

--- a/src/lib/jlpt-dictionary.ts
+++ b/src/lib/jlpt-dictionary.ts
@@ -87,7 +87,10 @@ export async function loadJLPTDictionary(
       datasetVersion?: unknown
       checksums?: { dataSha256?: unknown }
     }
-    const dataText = await dataResponse.text()
+    // Normalize CRLF -> LF before digesting: the manifest stores the LF hash, but
+    // a Windows checkout (core.autocrlf) serves CRLF. Lone CR is left untouched so
+    // the digest matches the generated LF content exactly.
+    const dataText = (await dataResponse.text()).replace(/\r\n/g, '\n')
     const data = JSON.parse(dataText) as Partial<DataFile>
     if (manifest.schemaVersion !== 1) {
       throw new Error('JLPT manifest schema is invalid')

--- a/src/lib/jlpt-grammar-dictionary.test.ts
+++ b/src/lib/jlpt-grammar-dictionary.test.ts
@@ -62,4 +62,19 @@ describe('loadJLPTGrammarDictionary', () => {
     )
     await expect(loadJLPTGrammarDictionary(levelFetch)).resolves.toMatchObject({ status: 'error' })
   })
+
+  it('verifies the checksum even when the served data has CRLF line endings', async () => {
+    // The generator writes LF and stores the LF hash in the manifest. A Windows
+    // checkout with core.autocrlf serves CRLF; the loader must normalize before
+    // digesting or every Windows dev/CI sees "JLPT grammar data checksum mismatch".
+    const fixtures = await responseSet()
+    const crlfDataText = fixtures.dataText.replace(/\n/g, '\r\n')
+    const fetchMock = async (input: RequestInfo | URL) => new Response(
+      String(input).includes('manifest') ? fixtures.manifestText : crlfDataText
+    )
+    const result = await loadJLPTGrammarDictionary(fetchMock)
+    expect(result.status).toBe('ready')
+    if (result.status !== 'ready') throw result.error
+    expect(result.dictionary.classify('〜ことにする')).toMatchObject({ level: 'N3', match: 'exact' })
+  })
 })

--- a/src/lib/jlpt-grammar-dictionary.ts
+++ b/src/lib/jlpt-grammar-dictionary.ts
@@ -79,7 +79,10 @@ export async function loadJLPTGrammarDictionary(
       datasetVersion?: unknown
       checksums?: { dataSha256?: unknown }
     }
-    const dataText = await dataResponse.text()
+    // Normalize CRLF -> LF before digesting: the manifest stores the LF hash, but
+    // a Windows checkout (core.autocrlf) serves CRLF. Lone CR is left untouched so
+    // the digest matches the generated LF content exactly.
+    const dataText = (await dataResponse.text()).replace(/\r\n/g, '\n')
     const data = JSON.parse(dataText) as Partial<DataFile>
     if (manifest.schemaVersion !== 1) {
       throw new Error('JLPT grammar manifest schema is invalid')


### PR DESCRIPTION
## Problem

On a Windows checkout with `core.autocrlf`, every analysis showed:

> JLPT 词表暂不可用,当前定级不会写入缓存。

JLPT level calibration fell back to `status: 'error'`, so vocabulary showed as unclassified and calibration results were not written to the cache / SRS.

## Root cause

The JLPT loaders digest the fetched data file and compare its SHA-256 to the manifest. The generator writes **LF** and the manifest stores the **LF** hash. But `core.autocrlf` expands the checked-out `public/data/*.json` to **CRLF** in the working tree, so the dev server serves CRLF, the digest diverges, and verification throws `JLPT data checksum mismatch`. Both the vocabulary and grammar loaders were affected.

```
manifest expected (LF):  5219af8a...
working tree CRLF:        403ba201...  (mismatch)
CRLF->LF:                 5219af8a...  (matches manifest)
```

The repo blobs were already LF (correct); only the Windows working tree was CRLF.

## Fix (two layers)

1. **Runtime defense** - normalize CRLF -> LF before digesting in both `loadJLPTDictionary` and `loadJLPTGrammarDictionary`. Lone CR is left untouched, so the digest still matches the generated LF content exactly; integrity is preserved (an attacker would still need a SHA-256 preimage). This protects any Windows contributor / CI regardless of their autocrlf setting.
2. **Source prevention** - add `.gitattributes` forcing `public/data/**` to `eol=lf`, so future checkouts keep LF in the working tree. Existing repo blobs were already LF, so no data-file content change is needed; only the local working tree was rewritten to LF.

## Tests (TDD)

Added a CRLF-tolerance test to each loader's test file. Confirmed both fail before the fix (reproducing the bug) and pass after.

## Verification

- `npm test` -> 240/240 pass (32/32 files)
- `npm run lint -- --quiet` -> clean
- `npm run build` -> green
- Direct SHA-256 of both working-tree data files now matches the manifest with no normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)