### PR TITLE
fix(deps): restrict Dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,22 @@
 version: 2
 updates:
-  # npm dependencies — security updates only via grouped PRs to avoid noise.
+  # Root npm dependencies — security updates only, grouped to avoid noise.
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
       day: monday
-    # Group all security updates into a single PR so we get one review per
-      # week instead of dozens. Non-security updates are left to manual bumps.
+    # Disable scheduled version-update PRs. Security updates remain enabled
+    # and are grouped explicitly below.
+    open-pull-requests-limit: 0
     groups:
       security:
-        update-types:
-          - patch
-          - minor
-          - major
-    open-pull-requests-limit: 5
+        applies-to: security-updates
+        patterns:
+          - '*'
     commit-message:
       prefix: chore(deps)
       include: scope
-    # Only open PRs for security advisories, not routine version bumps.
-    # This keeps the queue short for a solo-maintained project.
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
   # Netlify functions backend has its own lockfile — track it separately so its
   # security advisories get PRs too.
   - package-ecosystem: npm
@@ -30,19 +24,15 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 0
     groups:
       security:
-        update-types:
-          - patch
-          - minor
-          - major
-    open-pull-requests-limit: 5
+        applies-to: security-updates
+        patterns:
+          - '*'
     commit-message:
       prefix: chore(deps)
       include: scope
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
   # GitHub Actions — keep workflow action versions current.
   - package-ecosystem: github-actions
     directory: /

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -43,3 +43,7 @@ CI 通过 `npm run check:docs`(`scripts/check-docs-index.mjs`)校验本索引列
 - **OPENAI_BASE_URL 修复** — OpenAIService 尊重 `OPENAI_BASE_URL`(ARK 等兼容端点)+ 真实错误透传。 [plan](plans/2026-07-13-openai-base-url.md)
 - **文本分析超时加固** — 修复超时重试放大、加有界批并发与逐批重试、超时 env 可调。 [spec](specs/2026-07-14-text-analysis-timeout-design.md) · [plan](plans/2026-07-14-text-analysis-timeout.md)
 - **文本阅读逐句分栏** - 文本结果改左右分栏:左侧逐句列表点击切换,右侧显示选中句的翻译/词汇/语法,复用 MokuroAnalysisPanel。 [plan](plans/2026-07-14-text-sentence-viewer.md)
+
+## 工程维护
+
+- **Dependabot 仅安全更新** — 禁止普通版本更新混入安全分组,保留根项目和 Netlify 的分组安全修复。 [plan](plans/2026-07-21-dependabot-security-only.md)

--- a/docs/superpowers/plans/2026-07-21-dependabot-security-only.md
+++ b/docs/superpowers/plans/2026-07-21-dependabot-security-only.md
@@ -1,0 +1,33 @@
+# Dependabot Security-Only Updates Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent routine dependency upgrades from being mislabeled and combined as security updates while preserving grouped Dependabot security fixes.
+
+**Architecture:** Keep the existing npm update jobs for the root app and Netlify runtime, but disable scheduled version-update pull requests with `open-pull-requests-limit: 0`. Apply each `security` group explicitly to `security-updates` and match all vulnerable dependencies. Major upgrades remain manual migrations with their own verification.
+
+**Tech Stack:** GitHub Dependabot v2 configuration, npm, GitHub Actions.
+
+### Task 1: Correct both npm update jobs
+
+**Files:**
+
+- Modify: `.github/dependabot.yml`
+
+1. Run a read-only Node assertion that requires both npm jobs to disable version PRs and declare an all-dependency security group; confirm it fails.
+2. Set `open-pull-requests-limit: 0` for `/` and `/netlify`.
+3. Set `applies-to: security-updates` and `patterns: ['*']` on both `security` groups.
+4. Remove misleading `update-types` and `allow` rules.
+5. Rerun the assertion and confirm it passes.
+
+### Task 2: Verify and publish
+
+**Files:**
+
+- Modify: `docs/superpowers/README.md`
+- Create: `docs/superpowers/plans/2026-07-21-dependabot-security-only.md`
+
+1. Run `npm run check:docs`, `npm test`, `npm run lint`, and `npm run build`.
+2. Run `git diff --check` and inspect the complete diff.
+3. Commit and push `codex/fix-dependabot-security-updates`.
+4. Open a ready pull request and close obsolete dependency PR #23 with the verified root cause.


### PR DESCRIPTION
## Summary

- disable routine npm version-update PRs for the root app and Netlify runtime
- explicitly group all Dependabot security updates with `applies-to: security-updates`
- document and index the maintenance policy

## Root cause

The previous `security` groups omitted `applies-to`, so Dependabot treated them as version-update groups. PR #23 consequently bundled 149 routine upgrades, including incompatible TypeScript 7, Tailwind 4, and ESLint 10 migrations. TypeScript 7 caused Next/Webpack to stop resolving the existing `@/components/*` aliases; restoring TypeScript 5.9 removed those module-resolution errors.

## Impact

Security advisories can still produce grouped Dependabot PRs. Routine dependency upgrades, especially breaking major versions, remain manual and can be migrated and verified independently.

## Validation

- Dependabot security-only assertion: passed for both npm jobs
- YAML parse: passed
- `npm run check:docs`: passed
- `npm test`: 34 files, 258 tests passed
- `npm run lint`: 0 errors, 7 existing `<img>` warnings
- `npm run build`: passed
- `git diff --check`: passed
- gitleaks: no leaks found

## References

- GitHub documentation: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates
